### PR TITLE
feat: update visual design and add recent posts section

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -29,6 +29,31 @@
   --font-mono: "SF Mono", Monaco, "Cascadia Mono", "Roboto Mono", monospace;
 }
 
+@media (prefers-color-scheme: light) {
+  :root {
+    /* Tokyo Night Light Colors */
+    --background: #d5d6db;
+    --foreground: #343b58;
+    --selection: #99c1f1;
+    --comment: #8c8fa1;
+    --blue: #2a7bde;
+    --red: #c01c28;
+    --yellow: #a2734c;
+    --green: #26a269;
+    --purple: #5d5db8;
+    --cyan: #1b9ef3;
+    --orange: #e66100;
+    --pink: #8c54fe;
+
+    /* UI Colors */
+    --surface: #e2e3e7;
+    --surface-light: #e6e7ed;
+    --border: #a1a6b5;
+    --border-light: #b7bac6;
+    --accent: #1c71d8;
+  }
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -52,33 +77,7 @@ body {
   position: relative;
 }
 
-/* Background pattern */
-body::before {
-  content: "";
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-image:
-    radial-gradient(
-      circle at 15% 50%,
-      rgba(122, 162, 247, 0.1) 0%,
-      transparent 20%
-    ),
-    radial-gradient(
-      circle at 85% 30%,
-      rgba(187, 154, 247, 0.1) 0%,
-      transparent 20%
-    ),
-    radial-gradient(
-      circle at 50% 80%,
-      rgba(42, 195, 222, 0.05) 0%,
-      transparent 20%
-    );
-  z-index: -1;
-  pointer-events: none;
-}
+
 
 /* Header & Navigation */
 .site-header {
@@ -90,10 +89,7 @@ body::before {
 .site-title {
   font-size: 2.5rem;
   font-weight: 700;
-  background: linear-gradient(135deg, var(--blue), var(--purple));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--blue);
   margin-bottom: 1rem;
   letter-spacing: -0.5px;
 }
@@ -125,7 +121,7 @@ body::before {
   left: 0;
   width: 0;
   height: 2px;
-  background: linear-gradient(90deg, var(--blue), var(--purple));
+  background: var(--blue);
   transition: width 0.3s ease;
 }
 
@@ -167,10 +163,7 @@ h6 {
 h1 {
   font-size: 1.5rem;
   margin-top: 1rem;
-  background: linear-gradient(135deg, var(--blue), var(--cyan));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--blue);
 }
 
 h2 {
@@ -328,6 +321,8 @@ article {
   color: var(--cyan);
 }
 
+
+
 .tag-list {
   display: flex;
   gap: 0.5rem;
@@ -336,7 +331,7 @@ article {
 }
 
 .tag {
-  background: linear-gradient(135deg, var(--surface-light), var(--border));
+  background: var(--surface-light);
   color: var(--blue);
   padding: 0.3rem 0.8rem;
   border-radius: 20px;
@@ -354,53 +349,20 @@ article {
 
 /* Blog List */
 .post-list {
-  list-style: none;
-  padding: 0;
-}
-
-.post-item {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 2rem;
+  list-style-type: disc;
+  padding-left: 2em;
   margin-bottom: 1.5rem;
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
 }
 
-.post-item::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0;
-  height: 100%;
-  width: 4px;
-  background: linear-gradient(to bottom, var(--blue), var(--purple));
-  opacity: 0;
-  transition: opacity 0.3s ease;
+.post-list li {
+  margin-bottom: 0.75rem;
 }
 
-.post-item:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
-  border-color: var(--border-light);
-}
 
-.post-item:hover::before {
-  opacity: 1;
-}
 
-.post-title {
-  font-size: 1.5rem;
-  margin-bottom: 0.5rem;
-}
 
-.post-summary {
-  color: var(--comment);
-  margin: 1rem 0;
-  line-height: 1.6;
-}
+
+
 
 .read-more {
   display: inline-flex;
@@ -419,6 +381,56 @@ article {
 .read-more:hover::after {
   transform: translateX(4px);
 }
+
+/* Tech Keywords */
+.tech-keywords {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  margin: 2rem auto;
+  max-width: min(56rem, 100%);
+}
+
+.tech-line {
+  display: contents;
+}
+
+.tech-line-1 .tech-keyword {
+  order: 1;
+}
+
+.tech-line-2 .tech-keyword {
+  order: 2;
+}
+
+.tech-line-3 .tech-keyword {
+  order: 3;
+}
+
+.tech-line-4 .tech-keyword {
+  order: 4;
+}
+
+/* Individual keyword styling remains the same */
+
+.tech-keyword {
+  background: var(--surface-light);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  color: var(--foreground);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  text-align: center;
+}
+
+
 
 /* Footer */
 .site-footer {
@@ -443,7 +455,7 @@ article {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  background: linear-gradient(135deg, var(--blue), var(--purple));
+  background: var(--blue);
   color: white;
   padding: 0.75rem 1.5rem;
   border-radius: 8px;
@@ -464,7 +476,7 @@ article {
 .hero {
   text-align: center;
   padding: 4rem 2rem;
-  background: linear-gradient(135deg, var(--surface-light), var(--surface));
+  background: var(--surface-light);
   border-radius: 16px;
   margin: 3rem 0;
   border: 1px solid var(--border);
@@ -564,6 +576,13 @@ article {
 }
 
 /* Responsive Design */
+@media (max-width: 1024px) {
+  .tech-keywords {
+    gap: 0.5rem;
+    max-width: min(40rem, 100%);
+  }
+}
+
 @media (max-width: 768px) {
   body {
     padding: 15px;
@@ -587,6 +606,16 @@ article {
 
   .site-nav {
     gap: 1rem;
+  }
+
+  .tech-keywords {
+    max-width: min(30rem, 100%);
+    gap: 0.4rem;
+  }
+  
+  .tech-keyword {
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
   }
 
   .hero {
@@ -635,7 +664,7 @@ article {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  background: linear-gradient(135deg, var(--blue), var(--purple));
+  background: var(--blue);
   color: white;
   padding: 0.75rem 1.5rem;
   border-radius: 8px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -62,6 +62,12 @@
                         <circle cx="4" cy="4" r="2"></circle>
                     </svg>
                 </a>
+                <a href="mailto:santiago.porollan@gmail.com" class="social-link" target="_blank" rel="noopener">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
+                        <polyline points="22,6 12,13 2,6"></polyline>
+                    </svg>
+                </a>
             </div>
             <p>sporollan/site v1</p>
         </div>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -4,130 +4,46 @@
         margin: 0 auto;
     }
     
-    .contact-grid {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 3rem;
-        margin-top: 2rem;
-    }
-    
-    @media (max-width: 768px) {
-        .contact-grid {
-            grid-template-columns: 1fr;
-        }
-    }
-    
     .contact-info {
-        background: var(--surface);
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 2rem;
-    }
-    
-    .contact-form {
-        background: var(--surface);
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 2rem;
-    }
-    
-    .form-group {
-        margin-bottom: 1.5rem;
-    }
-    
-    .form-label {
-        display: block;
-        margin-bottom: 0.5rem;
-        color: var(--blue);
-        font-weight: 500;
-    }
-    
-    .form-input,
-    .form-textarea {
-        width: 100%;
-        padding: 0.75rem 1rem;
-        background: var(--surface-light);
-        border: 1px solid var(--border-light);
-        border-radius: 8px;
-        color: var(--foreground);
-        font-family: var(--font-sans);
-        font-size: 1rem;
-        transition: all 0.2s ease;
-    }
-    
-    .form-input:focus,
-    .form-textarea:focus {
-        outline: none;
-        border-color: var(--blue);
-        box-shadow: 0 0 0 3px rgba(122, 162, 247, 0.1);
-    }
-    
-    .form-textarea {
-        min-height: 150px;
-        resize: vertical;
+        margin-top: 2rem;
     }
     
     .contact-details {
         list-style: none;
         padding: 0;
-        margin-top: 2rem;
+        margin: 1.5rem 0;
     }
     
     .contact-details li {
         display: flex;
-        align-items: flex-start;
-        gap: 1rem;
-        margin-bottom: 0rem;
-        padding-bottom: 0.5rem;
-        
+        align-items: baseline;
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
     }
     
     .contact-details li:last-child {
         border-bottom: none;
+        margin-bottom: 0;
+        padding-bottom: 0;
     }
     
-    .contact-icon {
-        background: linear-gradient(135deg, var(--blue), var(--purple));
-        color: white;
-        width: 40px;
-        height: 40px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+    .contact-label {
+        font-weight: 500;
+        color: var(--blue);
+        min-width: 5rem;
         flex-shrink: 0;
     }
     
-    .contact-detail-content h3 {
-        margin: 0 0 0.5rem 0;
-        font-size: 1.1rem;
-        color: var(--foreground);
+    .contact-details a {
+        color: var(--cyan);
+        text-decoration: none;
     }
     
-    .contact-detail-content p {
-        margin: 0;
-        color: var(--comment);
-    }
-    
-    .contact-success {
-        background: linear-gradient(135deg, var(--green), var(--cyan));
-        color: white;
-        padding: 1rem;
-        border-radius: 8px;
-        text-align: center;
-        margin-bottom: 2rem;
-        display: none;
-    }
-    
-    .contact-success.show {
-        display: block;
-    }
-    
-    .form-disclaimer {
-        font-size: 0.9rem;
-        color: var(--comment);
-        margin-top: 1rem;
-        text-align: center;
+    .contact-details a:hover {
+        color: var(--blue);
+        text-decoration: underline;
     }
 </style>
 {{end}}
@@ -142,31 +58,21 @@
     </article>
     {{end}}
     
-    <div class="contact-grid">
-        <div class="contact-info">
-            <h2>Get in Touch</h2>
-            <p>Feel free to reach out!</p>
-            
-            <ul class="contact-details">
-                <li>
-                    <div class="contact-detail-content">
-                        <p>santiago.porollan@gmail.com</p>
-                    </div>
-                </li>
-                <li>
-                    <div class="contact-detail-content">
-                        <a href="https://linkedin.com/in/santiago-porollan">Linkedin</a>
-                    </div>
-                </li>
-                <li>
-                    <div class="contact-detail-content">
-                        <a href="https://github.com/sporollan">Github</a>
-                    </div>
-                </li>
-            </ul>
-        
-        </div>
-        
+    <div class="contact-info">
+        <ul class="contact-details">
+            <li>
+                <span class="contact-label">Email:</span>
+                <a href="mailto:santiago.porollan@gmail.com">santiago.porollan@gmail.com</a>
+            </li>
+            <li>
+                <span class="contact-label">LinkedIn:</span>
+                <a href="https://linkedin.com/in/santiago-porollan">linkedin.com/in/santiago-porollan</a>
+            </li>
+            <li>
+                <span class="contact-label">GitHub:</span>
+                <a href="https://github.com/sporollan">github.com/sporollan</a>
+            </li>
+        </ul>
     </div>
 </div>
 {{end}}

--- a/templates/home.html
+++ b/templates/home.html
@@ -17,8 +17,68 @@
     <article class="mt-3">{{.Body | safeHTML}}</article>
     <h1>Highlighted Projects</h1>
     <ul>
+        <li><a href="https://github.com/sporollan/eks-terraform-url-shortener">EKS Terraform URL Shortener</a> - Production-Grade URL Shortener on AWS EKS </li>
         <li><a href="https://github.com/sporollan/site">This Site</a> - A Static Site Generator built in go.</li>
     </ul>
+    <h2>Quick Links</h2>
+    <ul>
+        <li><a href="https://github.com/sporollan">GitHub</a></li>
+        <li><a href="https://linkedin.com/in/santiago-porollan">LinkedIn</a></li>
+        <li><a href="mailto:santiago.porollan@gmail.com">Email</a></li>
+    </ul>
+    {{with .Metadata.RecentPosts}}
+    <h2>Recent Posts</h2>
+    <ul class="post-list">
+        {{range .}}
+        <li>
+            {{if not .Date.IsZero}}
+            <a href="{{.Permalink}}">{{.Date.Format "January 2, 2006"}}</a> - {{.Title}}
+            {{else}}
+            <a href="{{.Permalink}}">{{.Title}}</a>
+            {{end}}
+        </li>
+        {{end}}
+    </ul>
+    {{end}}
+    <div class="tech-keywords">
+        <div class="tech-line tech-line-1">
+            <span class="tech-keyword">Cloud-Native</span>
+            <span class="tech-keyword">Python</span>
+            <span class="tech-keyword">Go</span>
+            <span class="tech-keyword">AWS</span>
+            <span class="tech-keyword">Kubernetes</span>
+            <span class="tech-keyword">Docker</span>
+            <span class="tech-keyword">PostgreSQL</span>
+            <span class="tech-keyword">Redis</span>
+            <span class="tech-keyword">Terraform</span>
+        </div>
+        <div class="tech-line tech-line-2">
+            <span class="tech-keyword">Node.js</span>
+            <span class="tech-keyword">Javascript</span>
+            <span class="tech-keyword">Typescript</span>
+            <span class="tech-keyword">Monitoring</span>
+            <span class="tech-keyword">Linux</span>
+            <span class="tech-keyword">Git</span>
+            <span class="tech-keyword">CI/CD</span>
+            <span class="tech-keyword">REST APIs</span>
+            <span class="tech-keyword">Nginx</span>
+
+        </div>
+        <div class="tech-line tech-line-3">
+            <span class="tech-keyword">System Design</span>
+            <span class="tech-keyword">Microservices</span>
+            <span class="tech-keyword">gRPC</span>
+            <span class="tech-keyword">Prometheus</span>
+            <span class="tech-keyword">Grafana</span>
+        </div>
+        <div class="tech-line tech-line-4">
+            <span class="tech-keyword">Helm</span>
+            <span class="tech-keyword">Ansible</span>
+            <span class="tech-keyword">React</span>
+            <span class="tech-keyword">Continuous Integration</span>
+            <span class="tech-keyword">Continuous Delivery</span>
+        </div>
+    </div>
     {{end}} 
 </div>
 {{end}}

--- a/templates/list.html
+++ b/templates/list.html
@@ -8,39 +8,15 @@
 
 <ul class="post-list">
     {{range .Pages}}
-    <li class="post-item">
-        <h2 class="post-title">
-            <a href="{{.Permalink}}">{{.Title}}</a>
-        </h2>
-        
-        <div class="post-meta">
-            {{if not .Date.IsZero}}
-            <span class="post-date">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-                    <line x1="16" y1="2" x2="16" y2="6"></line>
-                    <line x1="8" y1="2" x2="8" y2="6"></line>
-                    <line x1="3" y1="10" x2="21" y2="10"></line>
-                </svg>
-                {{.Date.Format "January 2, 2006"}}
-            </span>
-            {{end}}
-        </div>
-        
-        {{if .Summary}}
-        <p class="post-summary">{{.Summary}}</p>
-        {{end}}
-        
-        {{if .Tags}}
-        <div class="tag-list">
-            {{range .Tags}}
-            <span class="tag">{{.}}</span>
-            {{end}}
-        </div>
+    <li>
+        {{if not .Date.IsZero}}
+        <a href="{{.Permalink}}">{{.Date.Format "January 2, 2006"}}</a> - {{.Title}}
+        {{else}}
+        <a href="{{.Permalink}}">{{.Title}}</a>
         {{end}}
     </li>
     {{else}}
-    <li class="post-item text-center">
+    <li>
         <p>No posts yet. Check back soon!</p>
     </li>
     {{end}}


### PR DESCRIPTION
- Simplify design: remove gradient backgrounds, radial patterns, gradient text
- Add automatic light theme with Tokyo Night Light palette
- Add recent posts section to home page (max 5 posts)
- Add quick links section with GitHub, LinkedIn, Email
- Implement responsive tech stack layout with centered scattering
- Fix half-screen width layout issues for tech keywords
- Update light theme box backgrounds to be lighter than page
- Remove icons from Go source code (checkmarks)
- Simplify template styles and consolidate CSS
- Add email icon to footer social links
Closes #13 